### PR TITLE
Firefox css fix for overly bold fonts on Mac OS X.

### DIFF
--- a/css/zocial.css
+++ b/css/zocial.css
@@ -60,6 +60,7 @@ a.zocial {
 	box-shadow: 0.075em 0 0 rgba(255,255,255,0.25);
 	
 	-moz-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	-webkit-font-smoothing: antialiased;
 	font-smoothing: antialiased;
 }


### PR DESCRIPTION
See [Issue #76 ]